### PR TITLE
Support default mount

### DIFF
--- a/src/pondo/electric.cljc
+++ b/src/pondo/electric.cljc
@@ -24,17 +24,28 @@
 
 (e/defn Mount
   [match F]
-  (when-let [[params new-active-route-data] (match active-route-data)]
-    (binding [active-route-data new-active-route-data
-              active-path (conj active-path match)]
-      (new F active-path params))))
+  (e/client
+    ;; Support "default" mount - that is, mount at this depth iff no other
+    ;; functions will mount at this depth.
+    ;; Particularly useful at the root of the tree to support the case where
+    ;; no routes are present.
+   (if (nil? match)
+     (when
+      (empty? active-route-data)
+       (new F active-path active-route-data))
+     (when-let [[params new-active-route-data] (match active-route-data)]
+       (binding [active-route-data new-active-route-data
+                 active-path (conj active-path match)]
+         (new F active-path params)
+         true)))))
 
 (e/defn Href [f]
-  (let [d (f root-route-data)
-        root-path (::root-path config)
-        encoded
-        (gstring/urlEncode (str d))]
-    (str root-path encoded)))
+  (e/client
+   (let [d (f root-route-data)
+         root-path (::root-path config)
+         encoded
+         (gstring/urlEncode (str d))]
+     (str root-path encoded))))
 
 (e/defn RouteData [path]
   (core/route-data-at path root-route-data))


### PR DESCRIPTION
Not sure if this is a good idea or not. This PR allows you to specify a mount like this:

```clojure
(mount nil (e/fn [_ _] ...))
```

Merging for now, but I feel like there is probably a better way to do this.